### PR TITLE
Define compatibility with Grunt 1.x in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-date-suffix",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Grunt plugin for renaming a file with date suffix.",
   "main": "lib/datesuffix.js",
   "scripts": {
@@ -24,12 +24,12 @@
   },
   "homepage": "https://github.com/iameugenejo/grunt-date-suffix",
   "devDependencies": {
-    "grunt": "^0.4.5",
+    "grunt": ">=0.4.5 <2.0.0",
     "mocha": "^2.1.0",
     "should": "^4.6.0"
   },
   "peerDependencies": {
-    "grunt": "^0.4.5"
+    "grunt": ">=0.4.5 <2.0.0"
   },
   "dependencies": {
     "date-format": "0.0.2",


### PR DESCRIPTION
Fixes the warning message:
`grunt-date-suffix@1.0.2 requires a peer of grunt@^0.4.5 but none was installed.`